### PR TITLE
Update script to use jira API tokens instead of cookie-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # alfred-jira-search
-An Alfred workflow to search for Jira tickets
+An Alfred workflow to search for Jira tickets.
 
 <p align="center" margin-bottom="0">
   <img width="520" height="auto" src="./.github/jira-multi.png" /> 
@@ -9,21 +9,26 @@ An Alfred workflow to search for Jira tickets
   <img width="520" height="auto" src="./.github/jira-single.png" /> 
 </p>
 
-The workflow is triggered by the **jira** keyword, followed up by the search query.  
+* The workflow is triggered by the **jira** keyword, followed up by the search query.  
+* Under the hood the workflow uses the [`/rest/api/3/issue/picker`](https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-issue-picker-get) endpoint to return a list of issues matching the Alfred query.  
+* It's smart enough to return a list of issues if you're query is a word, or a specific issue if your query is a ticket number.  
 
-Under the hood the workflow uses the [`/rest/api/3/issue/picker`](https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-issue-picker-get) endpoint to return a list of issues matching the Alfred query.  
-It's smart enough to return a list of issues if you're query is a word, or a specific issue if your query is a ticket number.  
+---
 
-The workflow setup still has a huge margin for improvement: I haven't built an authentication flow, so it  requires some manual setup (that I abstracted into two workflow environment variables).   
+The workflow setup still has a huge margin for improvement: I haven't built an authentication flow, so it  requires some manual setup (that I abstracted into three workflow environment variables).   
 
-__A `domain` variable__
-Part of the Jira URL.  
+
+__A `domain` variable__  
+Part of the Jira URL.
 E.g. `https://${domain}.atlassian.net`). 
 
-__A `header` variable__
-HTTP header used in the API requests.  
-You should add here your authentication token (JWT or cookie).  
-Personally, using the cookie session token is enough for me for now.  
-E.g.: `cookie:cloud.session.token=eyJraWQiOiJj...`.  
+__An `apitoken` variable__  
+The jira API token to use for authentication.
+You can generate one in your [jira account settings](https://confluence.atlassian.com/cloud/api-tokens-938839638.html)
 
-It also need [jq](https://stedolan.github.io/jq/) to be installed.   
+__A `username` variable__  
+The jira username associated with the API token.
+E.g. `foo@bar.com`
+
+
+It also needs [jq](https://stedolan.github.io/jq/) to be installed.   

--- a/script-filter.sh
+++ b/script-filter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Base URL of the API call
-baseurl="https://${domain}.atlassian.net/rest/api/3/issue/picker"
-
-#Even tried this with no luck
-curl -G -v -S $baseurl --data-urlencode "query=${1}" -H $header | /usr/local/bin/jq '.sections[0].issues | map({uid: .id, title: .key, subtitle: .summaryText, arg: .key }) | { items: . }'
+curl --request GET \
+     --url "https://${domain}.atlassian.net/rest/api/3/issue/picker?query=${1}" \
+     --user "${username}:${apitoken}" \
+     --header "Accept: application/json" \
+     | /usr/local/bin/jq '.sections[0].issues | map({uid: .id, title: .key, subtitle: .summaryText, arg: .key }) | { items: . }'


### PR DESCRIPTION
The JIRA cookie-based auth for REST APIs is [deprecated](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-cookie-based-authentication/). This PR updates the script to work with the favored [basic auth for REST APIs](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/).

I couldn't easily get the original script working with my API token, so I'm pushing this PR in case it helps others.